### PR TITLE
Update generic_member_service.rb

### DIFF
--- a/lib/ldap_fluff/generic_member_service.rb
+++ b/lib/ldap_fluff/generic_member_service.rb
@@ -23,10 +23,7 @@ class LdapFluff::GenericMemberService
   end
 
   def find_by_dn(dn)
-    entry, base = dn.split(/(?<!\\),/, 2)
-    entry_attr, entry_value = entry.split('=', 2)
-    entry_value = entry_value.gsub('\,', ',')
-    user = @ldap.search(:filter => name_filter(entry_value, entry_attr), :base => base)
+    user = @ldap.search(:base => dn, :scope => Net::LDAP::SearchScope_BaseObject)
     raise self.class::UIDNotFoundException if (user.nil? || user.empty?)
     user
   end


### PR DESCRIPTION
replacing inaccurate find_by_dn with a better solution.

Issue is original search can return duplicates:
CN=joe,OU=base,DC=xyz
CN=joe,OU=test,OU=base,DC=xyz

will both be present when looking for CN=joe using OU=base,DC=xyz as search base. Since it only wants to retrieve an object identified by the DN using that as the base of the search with the scope base feels more appropriate.